### PR TITLE
Upgrade log4j-core to version 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
          <dependency>
              <groupId>org.apache.logging.log4j</groupId>
              <artifactId>log4j-core</artifactId>
-             <version>2.13.2</version>
+             <version>2.15.0</version>
          </dependency>
  
              


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades log4j-core to 2.15.0 to fix vulnerabilities in current version